### PR TITLE
投稿機能を追加（entries作成・複数投稿対応） #16

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,10 @@ class ApplicationController < ActionController::Base
   private
 
   def guest_id_from_cookie
-    cookies.signed[:guest_id] ||= { value: SecureRandom.uuid, expires: 1.year }
+    cookies.signed[:guest_id] || begin
+      uuid = SecureRandom.uuid
+      cookies.signed[:guest_id] = { value: uuid, expires: 1.year }
+      uuid
+    end
   end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,0 +1,13 @@
+class EntriesController < ApplicationController
+  def create
+    moment = current_user.moments.find(params[:moment_id])
+    moment.entries.create!(entry_params)
+    redirect_to root_path
+  end
+
+  private
+
+  def entry_params
+    params.require(:entry).permit(:body)
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -28,11 +28,25 @@ class PagesController < ApplicationController
   }.freeze
 
   def index
-    @moment_country = Country.order("RANDOM()").first
-    return unless @moment_country
+    @current_moment = current_user.moments.find_by(id: session[:moment_id])
 
-    @local_time = Time.now.in_time_zone(@moment_country.timezone)
-    @fixed_text = fixed_text_for(@local_time.hour, @moment_country.name)
+    unless @current_moment
+      @moment_country = Country.order("RANDOM()").first
+      return unless @moment_country
+
+      @local_time     = Time.now.in_time_zone(@moment_country.timezone)
+      @fixed_text     = fixed_text_for(@local_time.hour, @moment_country.name)
+      @current_moment = current_user.moments.create!(
+        country:     @moment_country,
+        fixed_text:  @fixed_text,
+        occurred_at: @local_time
+      )
+      session[:moment_id] = @current_moment.id
+    end
+
+    @moment_country = @current_moment.country
+    @local_time     = @current_moment.occurred_at.in_time_zone(@moment_country.timezone)
+    @fixed_text     = @current_moment.fixed_text
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -30,9 +30,18 @@ class PagesController < ApplicationController
   def index
     @current_moment = current_user.moments.find_by(id: session[:moment_id])
 
+    if @current_moment&.occurred_at&.< (Time.now - 1.day)
+      session.delete(:moment_id)
+      @current_moment = nil
+    end
+
     unless @current_moment
       @moment_country = Country.order("RANDOM()").first
-      return unless @moment_country
+
+      unless @moment_country
+        @error_message = "表示できる国のデータがありません。"
+        return
+      end
 
       @local_time     = Time.now.in_time_zone(@moment_country.timezone)
       @fixed_text     = fixed_text_for(@local_time.hour, @moment_country.name)

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,3 +1,5 @@
 class Entry < ApplicationRecord
   belongs_to :moment
+
+  validates :body, presence: true
 end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -5,3 +5,8 @@
 <p><%= @local_time.strftime("%H:%M") %></p>
 <p><%= @fixed_text %></p>
 <p>いま、あなたはどんな時間を過ごしていますか？</p>
+
+<%= form_with model: [@current_moment, Entry.new] do |f| %>
+  <%= f.text_area :body %>
+  <%= f.submit "残す" %>
+<% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,12 +1,16 @@
 <h1>Meanwhile</h1>
 <p>Hello, Meanwhile!</p>
 
-<p><%= @moment_country.name %></p>
-<p><%= @local_time.strftime("%H:%M") %></p>
-<p><%= @fixed_text %></p>
-<p>いま、あなたはどんな時間を過ごしていますか？</p>
+<% if @error_message %>
+  <p><%= @error_message %></p>
+<% else %>
+  <p><%= @moment_country.name %></p>
+  <p><%= @local_time.strftime("%H:%M") %></p>
+  <p><%= @fixed_text %></p>
+  <p>いま、あなたはどんな時間を過ごしていますか？</p>
 
-<%= form_with model: [@current_moment, Entry.new] do |f| %>
-  <%= f.text_area :body %>
-  <%= f.submit "残す" %>
+  <%= form_with model: [@current_moment, Entry.new] do |f| %>
+    <%= f.text_area :body, placeholder: "今を書く。" %>
+    <%= f.submit "残す" %>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,8 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   root "pages#index"
+
+  resources :moments, only: [] do
+    resources :entries, only: [:create]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,6 @@ Rails.application.routes.draw do
   root "pages#index"
 
   resources :moments, only: [] do
-    resources :entries, only: [:create]
+    resources :entries, only: [ :create ]
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_08_055232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "countries", force: :cascade do |t|
+    t.string "country_code"
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.string "timezone"
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "entries", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.integer "moment_id"
+    t.datetime "updated_at", null: false
+    t.index ["moment_id"], name: "index_entries_on_moment_id"
+  end
+
+  create_table "moments", force: :cascade do |t|
+    t.integer "country_id"
+    t.datetime "created_at", null: false
+    t.text "fixed_text"
+    t.datetime "occurred_at"
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["country_id"], name: "index_moments_on_country_id"
+    t.index ["user_id"], name: "index_moments_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "guest_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["guest_id"], name: "index_users_on_guest_id", unique: true
+  end
 end


### PR DESCRIPTION
## 概要
投稿機能を実装しました。テキストエリアに入力して「残す」ボタンを押すと、
現在のmomentに紐づくentryとしてDBに保存されます。

## 実装内容
- EntriesControllerを作成（createアクション）
- momentsにネストしたentriesのルーティングを追加
- 投稿フォームをビューに追加（テキストエリア・「残す」ボタン）
- セッションでmoment_idを管理し、ページリロード時に同じmomentを使い回す
- 複数投稿対応（同じmomentに何度でも投稿可能）

## 動作確認
- 入力して「残す」を押すとDBに保存されること
- 同じmomentに複数のentryが保存されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create and save text entries tied to a specific moment via a new submission form and endpoint.

* **Behavioral Changes**
  * Sessions now reuse a previously saved moment to keep context across visits.
  * Guest identity persistence improved (stored for up to one year) for continuity.

* **Bug Fixes / Validation**
  * Entry submissions now enforce presence of body content and will surface errors if missing.

* **UI**
  * Page shows a clear error message when moment lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->