### PR TITLE
更新ボタン機能を追加・コメント追記 #17

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   # cookieのguest_idをもとにUserを取得または作成する。ビューからも参照可能
   def current_user
-    @current_user ||= User.find_or_create_by!(guest_id: guest_id_from_cookie)
+    @current_user ||= User.create_or_find_by!(guest_id: guest_id_from_cookie)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,14 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
 
+  # cookieのguest_idをもとにUserを取得または作成する。ビューからも参照可能
   def current_user
     @current_user ||= User.find_or_create_by!(guest_id: guest_id_from_cookie)
   end
 
   private
 
+  # cookieにguest_idが存在すればその値を返す。なければUUIDを生成してsigned cookieに1年間保存する
   def guest_id_from_cookie
     cookies.signed[:guest_id] || begin
       uuid = SecureRandom.uuid

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,4 +1,5 @@
 class EntriesController < ApplicationController
+  # 日記の投稿：current_userのmomentに紐づくentryを作成してトップページに戻る
   def create
     moment = current_user.moments.find(params[:moment_id])
     moment.entries.create!(entry_params)
@@ -7,6 +8,7 @@ class EntriesController < ApplicationController
 
   private
 
+  # 投稿フォームから受け取るパラメータをbodyのみに限定する
   def entry_params
     params.require(:entry).permit(:body)
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
+  # 時間帯ごとの定型文。%s に国名を埋め込んで使用する
   FIXED_TEXTS = {
     morning: [
       "%s では今、朝の時間が流れています。",
@@ -27,9 +28,11 @@ class PagesController < ApplicationController
     ]
   }.freeze
 
+  # トップページ：セッションのmomentを使い回すか、新しく作成してビューに渡す
   def index
     @current_moment = current_user.moments.find_by(id: session[:moment_id])
 
+    # momentが1日以上前の場合はセッションをリセットして作り直す
     if @current_moment&.occurred_at&.< (Time.now - 1.day)
       session.delete(:moment_id)
       @current_moment = nil
@@ -38,6 +41,7 @@ class PagesController < ApplicationController
     unless @current_moment
       @moment_country = Country.order("RANDOM()").first
 
+      # countriesテーブルが空の場合はエラーメッセージを表示して終了
       unless @moment_country
         @error_message = "表示できる国のデータがありません。"
         return
@@ -58,8 +62,15 @@ class PagesController < ApplicationController
     @fixed_text     = @current_moment.fixed_text
   end
 
+  # 更新ボタン：セッションのmoment_idを削除してトップページにリダイレクトする
+  def refresh
+    session.delete(:moment_id)
+    redirect_to root_path
+  end
+
   private
 
+  # 時刻（hour）と国名から、時間帯に応じた定型文をランダムに1文返す
   def fixed_text_for(hour, country_name)
     period = case hour
     when 4..10  then :morning

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,3 +1,4 @@
 class Country < ApplicationRecord
+  # この国が使われたmoment一覧
   has_many :moments
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,5 +1,7 @@
 class Entry < ApplicationRecord
+  # どのmomentに対する投稿かを紐づける
   belongs_to :moment
 
+  # 本文が空の投稿を保存しない
   validates :body, presence: true
 end

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -1,5 +1,10 @@
 class Moment < ApplicationRecord
+  # このmomentを作成したユーザー
   belongs_to :user
+
+  # このmomentで表示された国
   belongs_to :country
+
+  # このmomentに対して投稿された日記一覧
   has_many :entries
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
+  # このユーザーが持つmoment一覧
   has_many :moments
 end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -8,6 +8,7 @@
   <p><%= @local_time.strftime("%H:%M") %></p>
   <p><%= @fixed_text %></p>
   <p>いま、あなたはどんな時間を過ごしていますか？</p>
+  <%= button_to "更新", refresh_path, method: :post %>
 
   <%= form_with model: [@current_moment, Entry.new] do |f| %>
     <%= f.text_area :body, placeholder: "今を書く。" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,13 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
+  # トップページ：ランダムな国の「今」を表示する
   root "pages#index"
 
+  # 更新ボタン用：セッションをリセットして新しい国をランダムに表示する
+  post "refresh", to: "pages#refresh"
+
+  # 日記の投稿：moment に紐づく entry を作成する
   resources :moments, only: [] do
     resources :entries, only: [ :create ]
   end


### PR DESCRIPTION
## 概要
更新ボタンを押すと新しいmomentが生成され、
国・時刻・定型文が再生成される機能を追加しました。

## 実装内容
- config/routes.rbにPOST /refreshルートを追加
- PagesController#refreshアクションを追加
  （セッションのmoment_idを削除してトップページにリダイレクト）
- ビューに更新ボタンを追加
- 各ファイルに日本語コメントを追加

## 動作確認
- 更新ボタンを押すと国・時刻・定型文が変わること
- 更新後も投稿機能が正常に動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refresh action and button on the home page to reset the session and load a new country view.
  * Added endpoint to create entries for a specific moment.

* **Improvements**
  * Improved session/user handling for more consistent persistence across visits.
  * Added associations linking users, countries, moments, and entries for richer data relationships.

* **Bug Fixes**
  * Entries now require body content to prevent blank submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->