### PR TITLE
moment一覧表示機能を追加 #18

### DIFF
--- a/app/controllers/moments_controller.rb
+++ b/app/controllers/moments_controller.rb
@@ -1,0 +1,9 @@
+class MomentsController < ApplicationController
+  # 一覧ページ：current_userのmomentを新しい順に全件取得する
+  # entriesも同時に読み込んでN+1クエリを防ぐ
+  def index
+    @moments = current_user.moments
+                            .includes(:country, :entries)
+                            .order(created_at: :desc)
+  end
+end

--- a/app/views/moments/index.html.erb
+++ b/app/views/moments/index.html.erb
@@ -1,0 +1,19 @@
+<h1>これまでの「今」</h1>
+
+<% if @moments.empty? %>
+  <p>まだ記録がありません。</p>
+<% else %>
+  <% @moments.each do |moment| %>
+    <div>
+      <%# 国名・時刻・定型文を表示する %>
+      <p><%= moment.country.name %></p>
+      <p><%= moment.occurred_at.in_time_zone(moment.country.timezone).strftime("%H:%M") %></p>
+      <p><%= moment.fixed_text %></p>
+
+      <%# このmomentに紐づく日記一覧を表示する %>
+      <% moment.entries.each do |entry| %>
+        <p><%= entry.body %></p>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/moments/index.html.erb
+++ b/app/views/moments/index.html.erb
@@ -7,7 +7,8 @@
     <div>
       <%# 国名・時刻・定型文を表示する %>
       <p><%= moment.country.name %></p>
-      <p><%= moment.occurred_at.in_time_zone(moment.country.timezone).strftime("%H:%M") %></p>
+      <%# occurred_atがnilの場合は"--:--"を表示する %>
+      <p><%= moment.occurred_at&.in_time_zone(moment.country.timezone)&.strftime("%H:%M") || "--:--" %></p>
       <p><%= moment.fixed_text %></p>
 
       <%# このmomentに紐づく日記一覧を表示する %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,9 @@ Rails.application.routes.draw do
   # 更新ボタン用：セッションをリセットして新しい国をランダムに表示する
   post "refresh", to: "pages#refresh"
 
+  # momentの一覧ページ：これまでの「今」と日記を振り返る
   # 日記の投稿：moment に紐づく entry を作成する
-  resources :moments, only: [] do
+  resources :moments, only: [ :index ] do
     resources :entries, only: [ :create ]
   end
 end


### PR DESCRIPTION
## 概要
ゲストユーザーのこれまでのmomentと、
各momentに紐づくentriesを一覧表示する機能を追加しました。

## 実装内容
- MomentsControllerを新規作成（indexアクション）
- current_userのmomentsを新しい順に全件取得
- includes(:country, :entries)でN+1クエリを防止
- app/views/moments/index.html.erbを新規作成
- ルーティングにGET /momentsを追加

## 動作確認
- /momentsにアクセスすると一覧が表示されること
- 各momentの国名・時刻・定型文が表示されること
- 各momentに紐づくentriesのbodyが表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Moments history page (titled "これまでの「今」") showing your past moments in reverse chronological order. Each moment displays the country, local time (converted to the country’s timezone with "--:--" fallback if unknown), the moment's text, and any related entries; shows a clear message when there are no moments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->