### PR TITLE
feat: UIデザイン調整 #19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 # Ignore key files for decrypting credentials and more.
 /config/*.key
 
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem "pg", "~> 1.1"
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
+# Tailwind CSSをRailsに統合する（専用CLIでビルドを管理）
+gem "tailwindcss-rails"
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,11 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
+    tailwindcss-rails (4.4.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.2.2-aarch64-linux-gnu)
+    tailwindcss-ruby (4.2.2-x86_64-linux-gnu)
     thor (1.5.0)
     thruster (0.1.20-aarch64-linux)
     thruster (0.1.20-x86_64-linux)
@@ -379,6 +384,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   stimulus-rails
+  tailwindcss-rails
   thruster
   turbo-rails
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -2,7 +2,15 @@ class EntriesController < ApplicationController
   # 日記の投稿：current_userのmomentに紐づくentryを作成してトップページに戻る
   def create
     moment = current_user.moments.find(params[:moment_id])
-    moment.entries.create!(entry_params)
+
+    # bodyが空の場合は保存せずそのままトップページへ戻る
+    if entry_params[:body].blank?
+      redirect_to root_path
+      return
+    end
+
+    # create!ではなくcreateを使いバリデーション失敗時もエラーページを出さない
+    moment.entries.create(entry_params)
     redirect_to root_path
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,30 +1,30 @@
 class PagesController < ApplicationController
-  # 時間帯ごとの定型文。%s に国名を埋め込んで使用する
+  # 時間帯ごとの定型文。%s に国名を埋め込んで使用する。すべて「%s では〜」形式で統一
   FIXED_TEXTS = {
     morning: [
-      "%s では今、朝の時間が流れています。",
-      "%s の朝は、静かに始まろうとしています。",
-      "%s の誰かが、今日最初の一歩を踏み出しています。"
+      "%s では今、朝の光が静かに広がっています。",
+      "%s では今、新しい一日が始まろうとしています。",
+      "%s では今、朝の気配が街に漂っています。"
     ],
     noon: [
-      "%s では今、昼の光が降り注いでいます。",
-      "%s の誰かが、今日の折り返し地点に立っています。",
-      "%s では今、一日の真ん中を過ごしています。"
+      "%s では今、昼の陽射しが降り注いでいます。",
+      "%s では今、一日の折り返し地点を迎えています。",
+      "%s では今、街が昼の賑わいに包まれています。"
     ],
     evening: [
-      "%s では今、夕暮れが街を染めています。",
-      "%s の誰かが、窓の外の夕陽を眺めています。",
+      "%s では今、夕暮れが街を染め始めています。",
+      "%s では今、西の空がだんだんと赤く染まっています。",
       "%s では今、一日の終わりが近づいています。"
     ],
     night: [
-      "%s では今、夜が深まっています。",
-      "%s の誰かが、今日を振り返る時間を過ごしています。",
-      "%s では今、街の灯りがともっています。"
+      "%s では今、夜の帳が下りています。",
+      "%s では今、街の灯りがともっています。",
+      "%s では今、人々が今日を振り返る時間を過ごしています。"
     ],
     midnight: [
       "%s では今、深夜の静けさが広がっています。",
-      "%s の誰かが、眠れない夜を過ごしています。",
-      "%s では今、ほとんどの人が夢の中にいます。"
+      "%s では今、ほとんどの人が夢の中にいます。",
+      "%s では今、夜が最も深い時間を迎えています。"
     ]
   }.freeze
 
@@ -54,17 +54,23 @@ class PagesController < ApplicationController
         fixed_text:  @fixed_text,
         occurred_at: @local_time
       )
-      session[:moment_id] = @current_moment.id
+      session[:moment_id]   = @current_moment.id
+      # 新しいmomentが作成されたときにポップアップを表示するフラグをセット
+      session[:show_popup]  = true
     end
 
     @moment_country = @current_moment.country
     @local_time     = @current_moment.occurred_at.in_time_zone(@moment_country.timezone)
     @fixed_text     = @current_moment.fixed_text
+
+    # ポップアップ表示フラグをビューに渡してからセッションから削除する
+    @show_popup = session.delete(:show_popup)
   end
 
-  # 更新ボタン：セッションのmoment_idを削除してトップページにリダイレクトする
+  # 更新ボタン：セッションをリセットしてポップアップを再表示する
   def refresh
     session.delete(:moment_id)
+    session[:show_popup] = true
     redirect_to root_path
   end
 

--- a/app/javascript/controllers/bottom_sheet_controller.js
+++ b/app/javascript/controllers/bottom_sheet_controller.js
@@ -1,8 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
-// ボトムシートおよびポップアップの開閉を管理するコントローラー
+// ボトムシートおよびポップアップ（Step1〜3）の開閉・遷移を管理するコントローラー
 export default class extends Controller {
-  static targets = ["sheet", "overlay", "step1", "step2"]
+  static targets = ["sheet", "overlay", "popupOverlay", "step1", "step2", "step3"]
 
   // ＋ボタンが押されたらボトムシートとオーバーレイを表示する
   open() {
@@ -16,15 +16,28 @@ export default class extends Controller {
     this.overlayTarget.classList.add("hidden")
   }
 
-  // Step1（国・時刻表示）を非表示にしてStep2（質問・入力）を表示する
+  // 現在表示中のStepを非表示にして次のStepを表示する
+  // Step1 → Step2 → Step3 の順に進む
   nextStep() {
-    this.step1Target.classList.add("hidden")
-    this.step2Target.classList.remove("hidden")
+    if (!this.step1Target.classList.contains("hidden")) {
+      // Step1が表示中 → Step2へ
+      this.step1Target.classList.add("hidden")
+      this.step2Target.classList.remove("hidden")
+    } else if (!this.step2Target.classList.contains("hidden")) {
+      // Step2が表示中 → Step3へ
+      this.step2Target.classList.add("hidden")
+      this.step3Target.classList.remove("hidden")
+    }
   }
 
-  // Step1・Step2両方を非表示にしてポップアップを閉じる
-  closePopup() {
+  // Step1〜3およびポップアップオーバーレイをすべて非表示にしてポップアップを閉じる
+  // eventを受け取りデフォルト動作とバブリングを止めることでフォーム送信を完全にブロックする
+  closePopup(event) {
+    event.preventDefault()
+    event.stopPropagation()
     this.step1Target.classList.add("hidden")
     this.step2Target.classList.add("hidden")
+    this.step3Target.classList.add("hidden")
+    this.popupOverlayTarget.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/bottom_sheet_controller.js
+++ b/app/javascript/controllers/bottom_sheet_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// ボトムシートの開閉を管理するコントローラー
+export default class extends Controller {
+  static targets = ["sheet", "overlay"]
+
+  // ＋ボタンが押されたらボトムシートとオーバーレイを表示する
+  open() {
+    this.sheetTarget.classList.remove("hidden")
+    this.overlayTarget.classList.remove("hidden")
+  }
+
+  // ✕ボタンまたはオーバーレイをタップしたら閉じる
+  close() {
+    this.sheetTarget.classList.add("hidden")
+    this.overlayTarget.classList.add("hidden")
+  }
+}

--- a/app/javascript/controllers/bottom_sheet_controller.js
+++ b/app/javascript/controllers/bottom_sheet_controller.js
@@ -1,8 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
-// ボトムシートの開閉を管理するコントローラー
+// ボトムシートおよびポップアップの開閉を管理するコントローラー
 export default class extends Controller {
-  static targets = ["sheet", "overlay"]
+  static targets = ["sheet", "overlay", "step1", "step2"]
 
   // ＋ボタンが押されたらボトムシートとオーバーレイを表示する
   open() {
@@ -14,5 +14,17 @@ export default class extends Controller {
   close() {
     this.sheetTarget.classList.add("hidden")
     this.overlayTarget.classList.add("hidden")
+  }
+
+  // Step1（国・時刻表示）を非表示にしてStep2（質問・入力）を表示する
+  nextStep() {
+    this.step1Target.classList.add("hidden")
+    this.step2Target.classList.remove("hidden")
+  }
+
+  // Step1・Step2両方を非表示にしてポップアップを閉じる
+  closePopup() {
+    this.step1Target.classList.add("hidden")
+    this.step2Target.classList.add("hidden")
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,5 +28,32 @@
     <main>
       <%= yield %>
     </main>
+
+    <%# 画面下部に固定されたタブナビゲーション %>
+    <nav class="fixed bottom-0 left-0 right-0 flex border-t border-gray-200" style="background-color: #fdf8f3;">
+
+      <%# ホームタブ：current_page?でアクティブ判定し、色を切り替える %>
+      <%= link_to root_path, class: "flex flex-col items-center justify-center flex-1 py-3 text-sm font-medium" do %>
+        <% if current_page?(root_path) %>
+          <span class="text-2xl" style="color: #b85c38;">🏠</span>
+          <span style="color: #b85c38;">ホーム</span>
+        <% else %>
+          <span class="text-2xl" style="color: #7a6552;">🏠</span>
+          <span style="color: #7a6552;">ホーム</span>
+        <% end %>
+      <% end %>
+
+      <%# 一覧タブ：current_page?でアクティブ判定し、色を切り替える %>
+      <%= link_to moments_path, class: "flex flex-col items-center justify-center flex-1 py-3 text-sm font-medium" do %>
+        <% if current_page?(moments_path) %>
+          <span class="text-2xl" style="color: #b85c38;">📋</span>
+          <span style="color: #b85c38;">一覧</span>
+        <% else %>
+          <span class="text-2xl" style="color: #7a6552;">📋</span>
+          <span style="color: #7a6552;">一覧</span>
+        <% end %>
+      <% end %>
+
+    </nav>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,10 +20,13 @@
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <%= yield %>
+    <main>
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
       <%= yield %>
     </main>
 
-    <%# 画面下部に固定されたタブナビゲーション %>
+    <%# 画面下部に固定されたタブナビゲーション。背景色：#fdf8f3（オフホワイト） %>
     <nav class="fixed bottom-0 left-0 right-0 flex border-t border-gray-200" style="background-color: #fdf8f3;">
 
       <%# ホームタブ：current_page?でアクティブ判定し、色を切り替える %>

--- a/app/views/moments/index.html.erb
+++ b/app/views/moments/index.html.erb
@@ -1,20 +1,68 @@
-<h1>これまでの「今」</h1>
+<%# ページ全体のラッパー %>
+<div class="min-h-screen pb-20" style="background-color: #f0ede8;">
 
-<% if @moments.empty? %>
-  <p>まだ記録がありません。</p>
-<% else %>
-  <% @moments.each do |moment| %>
-    <div>
-      <%# 国名・時刻・定型文を表示する %>
-      <p><%= moment.country.name %></p>
-      <%# occurred_atがnilの場合は"--:--"を表示する %>
-      <p><%= moment.occurred_at&.in_time_zone(moment.country.timezone)&.strftime("%H:%M") || "--:--" %></p>
-      <p><%= moment.fixed_text %></p>
+  <%# ページヘッダー：アプリ名（左）とページタイトル（右）を横並びで表示 %>
+  <header class="flex items-center justify-between px-6 py-4" style="background-color: #fdf8f3;">
+    <p class="text-xl font-bold" style="color: #4B2D1C;">Meanwhile</p>
+    <p class="text-sm" style="color: #7a6552;">これまでの「今」</p>
+  </header>
 
-      <%# このmomentに紐づく日記一覧を表示する %>
-      <% moment.entries.each do |entry| %>
-        <p><%= entry.body %></p>
-      <% end %>
-    </div>
+  <div class="px-4 pt-6">
+
+  <% if @moments.empty? %>
+    <%# momentがまだない場合のメッセージ %>
+    <p class="text-center text-sm mt-16" style="color: #7a6552;">まだ記録がありません。</p>
+  <% else %>
+
+    <%# momentカード一覧（新しい順） %>
+    <% @moments.each do |moment| %>
+      <div class="mb-4 rounded-2xl overflow-hidden shadow-sm">
+
+        <%# カード上部：国名・日付（左）と現地時刻（右）を横並びで表示 %>
+        <div class="flex items-center justify-between px-4 py-3" style="background-color: #e8f0f5;">
+          <div>
+            <%# 国旗絵文字：country_codeで条件分岐して表示する %>
+            <%# 国名 %>
+            <p class="text-xs font-medium" style="color: #7a6552;">
+              <%= case moment.country.country_code
+                  when "KR" then "🇰🇷"
+                  when "TR" then "🇹🇷"
+                  when "BR" then "🇧🇷"
+                  when "SE" then "🇸🇪"
+                  when "AU" then "🇦🇺"
+                  when "KE" then "🇰🇪"
+                  end %>
+              <%= moment.country.name %>
+            </p>
+            <%# 現地の日付（occurred_atをその国のタイムゾーンに変換）と日本時間での記録時刻を並べて表示 %>
+            <p class="text-xs mt-0.5" style="color: #7a6552;">
+              <%= moment.occurred_at&.in_time_zone(moment.country.timezone)&.strftime("%-m月%-d日") %>
+              <%= moment.created_at.in_time_zone("Tokyo").strftime("%H:%M") %>
+            </p>
+          </div>
+          <%# 現地時刻（大きめで右側に表示） %>
+          <p class="text-3xl font-bold tracking-tight" style="color: #4B2D1C;">
+            <%= moment.occurred_at&.in_time_zone(moment.country.timezone)&.strftime("%H:%M") || "--:--" %>
+          </p>
+        </div>
+
+        <%# カード下部：entriesをバブル形式で右寄せ表示 %>
+        <div class="bg-white px-4 py-3 min-h-12">
+          <% if moment.entries.any? %>
+            <div class="flex flex-col items-end gap-2">
+              <% moment.entries.each do |entry| %>
+                <%# entryバブル：右寄せ・テラコッタ背景・白テキスト %>
+                <span class="inline-block px-4 py-2 rounded-full text-sm text-white" style="background-color: #b85c38;">
+                  <%= entry.body %>
+                </span>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+      </div>
+    <% end %>
+
   <% end %>
-<% end %>
+  </div>
+</div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,17 +1,79 @@
-<h1>Meanwhile</h1>
-<p>Hello, Meanwhile!</p>
+<%# ページ全体のラッパー。ボトムシートコントローラーをここにマウントする %>
+<div class="min-h-screen pb-20" style="background-color: #fdf8f3;" data-controller="bottom-sheet">
 
-<% if @error_message %>
-  <p><%= @error_message %></p>
-<% else %>
-  <p><%= @moment_country.name %></p>
-  <p><%= @local_time.strftime("%H:%M") %></p>
-  <p><%= @fixed_text %></p>
-  <p>いま、あなたはどんな時間を過ごしていますか？</p>
-  <%= button_to "更新", refresh_path, method: :post %>
+  <% if @error_message %>
+    <%# 国データがない場合のエラーメッセージ %>
+    <div class="p-6">
+      <p class="text-sm" style="color: #b85c38;"><%= @error_message %></p>
+    </div>
+  <% else %>
 
-  <%= form_with model: [@current_moment, Entry.new] do |f| %>
-    <%= f.text_area :body, placeholder: "今を書く。" %>
-    <%= f.submit "残す" %>
+    <%# ヘッダー：アプリ名と更新ボタン %>
+    <header class="flex items-center justify-between px-6 pt-10 pb-4">
+      <h1 class="text-xl font-bold tracking-wide" style="color: #7a6552;">Meanwhile</h1>
+      <%# 更新ボタン：新しい国をランダムに表示する %>
+      <%= button_to "更新", refresh_path, method: :post,
+            class: "px-4 py-2 rounded-full text-sm font-medium text-white",
+            style: "background-color: #b85c38;" %>
+    </header>
+
+    <%# 国・時刻・定型文のカード %>
+    <section class="mx-6 mt-4 rounded-2xl p-6 shadow-sm bg-white">
+      <%# 国名 %>
+      <p class="text-sm font-medium mb-2" style="color: #7a6552;">
+        <%= @moment_country.name %>
+      </p>
+      <%# 時刻（大きめフォントで表示） %>
+      <p class="text-6xl font-bold tracking-tight mb-4" style="color: #b85c38;">
+        <%= @local_time.strftime("%H:%M") %>
+      </p>
+      <%# 定型文 %>
+      <p class="text-base leading-relaxed" style="color: #7a6552;">
+        <%= @fixed_text %>
+      </p>
+    </section>
+
+    <%# 質問文 %>
+    <p class="text-center mt-8 text-sm" style="color: #7a6552;">
+      いま、あなたはどんな時間を過ごしていますか？
+    </p>
+
+    <%# ＋ボタン：タップするとボトムシートを開く %>
+    <button data-action="bottom-sheet#open"
+            class="fixed right-6 bottom-24 w-14 h-14 rounded-full text-white text-3xl shadow-lg flex items-center justify-center"
+            style="background-color: #b85c38;">
+      +
+    </button>
+
+    <%# オーバーレイ：ボトムシート表示時に背景を暗転させる。タップで閉じる %>
+    <div data-bottom-sheet-target="overlay"
+         data-action="click->bottom-sheet#close"
+         class="hidden fixed inset-0 bg-black/40 z-10">
+    </div>
+
+    <%# ボトムシート：投稿フォームを収納する。デフォルト非表示 %>
+    <div data-bottom-sheet-target="sheet"
+         class="hidden fixed bottom-0 left-0 right-0 rounded-t-2xl bg-white p-6 z-20 shadow-xl">
+      <%# ボトムシートのヘッダー：現在の日時と✕ボタンを横並びで表示する %>
+      <div class="flex items-center justify-between mb-4">
+        <%# 投稿時の現在日時を日本時間で「4月12日 16:07」形式で表示する %>
+        <p class="text-sm" style="color: #7a6552;"><%= Time.current.in_time_zone("Tokyo").strftime("%-m月%-d日 %H:%M") %></p>
+        <%# ✕ボタン：ボトムシートを閉じる %>
+        <button data-action="bottom-sheet#close"
+                class="text-xl" style="color: #7a6552;">✕</button>
+      </div>
+      <%# 投稿フォーム %>
+      <%= form_with model: [@current_moment, Entry.new] do |f| %>
+        <%= f.text_area :body,
+              placeholder: "今を書く。",
+              rows: 4,
+              class: "w-full rounded-xl p-4 text-sm resize-none focus:outline-none border",
+              style: "border-color: #e5d5c5; color: #7a6552;" %>
+        <%= f.submit "残す",
+              class: "mt-4 w-full py-3 rounded-full text-white font-medium cursor-pointer",
+              style: "background-color: #b85c38;" %>
+      <% end %>
+    </div>
+
   <% end %>
-<% end %>
+</div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -107,6 +107,60 @@
 
     </div><%# /チャットエリア %>
 
+    <%# ポップアップオーバーレイ：Step1・Step2共通の背景暗転 %>
+    <% popup_hidden = @show_popup ? "" : "hidden" %>
+    <div class="<%= popup_hidden %> fixed inset-0 bg-black/50 z-30 flex items-center justify-center px-6">
+
+      <%# Step1ポップアップ：国・時刻を表示する。新しいmoment作成時に自動表示 %>
+      <div data-bottom-sheet-target="step1"
+           class="<%= popup_hidden %> bg-white rounded-3xl p-8 w-full max-w-sm text-center shadow-xl">
+        <%# 国旗と国名 %>
+        <p class="text-4xl mb-2"><%= flag %></p>
+        <p class="text-sm font-medium mb-4" style="color: #7a6552;"><%= @moment_country.name %></p>
+        <%# 現地時刻（大きく表示） %>
+        <p class="text-6xl font-bold tracking-tight mb-6" style="color: #4B2D1C;">
+          <%= @local_time.strftime("%H:%M") %>
+        </p>
+        <%# 次へボタン：Step2に切り替える %>
+        <button data-action="bottom-sheet#nextStep"
+                class="w-full py-3 rounded-full text-white font-medium"
+                style="background-color: #b85c38;">
+          次へ →
+        </button>
+      </div>
+
+      <%# Step2ポップアップ：質問と投稿フォームを表示する。常にhiddenでStep1の「次へ」で表示 %>
+      <div data-bottom-sheet-target="step2"
+           class="hidden bg-white rounded-3xl p-8 w-full max-w-sm shadow-xl">
+        <%# 質問文 %>
+        <p class="text-base font-medium mb-6 text-center" style="color: #4B2D1C;">
+          あなたは今、何をしていますか？
+        </p>
+        <%# 投稿フォーム %>
+        <%= form_with model: [@current_moment, Entry.new] do |f| %>
+          <%= f.text_area :body,
+                placeholder: "今を書く。",
+                rows: 4,
+                class: "w-full rounded-xl p-4 text-sm resize-none focus:outline-none border",
+                style: "border-color: #e5d5c5; color: #7a6552;" %>
+          <div class="flex gap-3 mt-4">
+            <%# とじるボタン：Step1・Step2両方を閉じる %>
+            <button type="button"
+                    data-action="bottom-sheet#closePopup"
+                    class="flex-1 py-3 rounded-full text-sm font-medium border"
+                    style="color: #7a6552; border-color: #e5d5c5;">
+              とじる
+            </button>
+            <%# 残すボタン：フォームを送信する %>
+            <%= f.submit "残す",
+                  class: "flex-1 py-3 rounded-full text-white font-medium cursor-pointer",
+                  style: "background-color: #b85c38;" %>
+          </div>
+        <% end %>
+      </div>
+
+    </div><%# /ポップアップ %>
+
     <%# ＋ボタン：タップするとボトムシートを開く %>
     <button data-action="bottom-sheet#open"
             class="fixed right-6 bottom-24 w-14 h-14 rounded-full text-white text-3xl shadow-lg flex items-center justify-center"

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,5 +1,5 @@
-<%# ページ全体のラッパー。ボトムシートコントローラーをここにマウントする %>
-<div class="min-h-screen pb-20" style="background-color: #f0ede8;" data-controller="bottom-sheet">
+<%# ページ全体のラッパー。背景色のみ指定し、data-controllerはポップアップ以下のdivに移動 %>
+<div class="min-h-screen pb-20" style="background-color: #f0ede8;">
 
   <% if @error_message %>
     <%# 国データがない場合のエラーメッセージ %>
@@ -38,8 +38,9 @@
         <div class="flex flex-col items-end gap-2">
           <%# アプリ名：フォントサイズを大きく %>
           <p class="text-2xl font-bold" style="color: #4B2D1C;">Meanwhile</p>
-          <%# 更新ボタン：セッションをリセットして新しい国を表示する %>
+          <%# 更新ボタン：button_toでPOSTを発行してセッションをリセットし、新しい国を表示する。Turboを無効化してフルリロードで遷移する %>
           <%= button_to "更新", refresh_path, method: :post,
+                data: { turbo: false },
                 class: "px-4 py-1.5 rounded-full text-sm font-medium text-white",
                 style: "background-color: #b85c38;" %>
         </div>
@@ -107,21 +108,38 @@
 
     </div><%# /チャットエリア %>
 
-    <%# ポップアップオーバーレイ：Step1・Step2共通の背景暗転 %>
-    <% popup_hidden = @show_popup ? "" : "hidden" %>
-    <div class="<%= popup_hidden %> fixed inset-0 bg-black/50 z-30 flex items-center justify-center px-6">
+    <%# ボトムシートコントローラーのスコープ：ポップアップ・＋ボタン・オーバーレイ・ボトムシートをまとめて管理する %>
+    <div data-controller="bottom-sheet">
 
-      <%# Step1ポップアップ：国・時刻を表示する。新しいmoment作成時に自動表示 %>
+    <%# ポップアップオーバーレイ：Step1〜3共通の背景暗転＋ぼかし %>
+    <% popup_hidden = @show_popup ? "" : "hidden" %>
+    <%# country_codeから英語国名（大文字）を取得する %>
+    <% english_name = case @moment_country.country_code
+                      when "KR" then "KOREA"
+                      when "TR" then "TURKEY"
+                      when "BR" then "BRAZIL"
+                      when "SE" then "SWEDEN"
+                      when "AU" then "AUSTRALIA"
+                      when "KE" then "KENYA"
+                      end %>
+    <%# popupOverlayターゲット：closePopup()でオーバーレイごと非表示にするために付与する %>
+    <div data-bottom-sheet-target="popupOverlay"
+         class="<%= popup_hidden %> fixed inset-0 bg-black/50 backdrop-blur-sm z-30 flex items-center justify-center px-6">
+
+      <%# Step1ポップアップ：国旗・英語国名・現地時刻を表示する。新しいmoment作成時に自動表示 %>
       <div data-bottom-sheet-target="step1"
            class="<%= popup_hidden %> bg-white rounded-3xl p-8 w-full max-w-sm text-center shadow-xl">
-        <%# 国旗と国名 %>
-        <p class="text-4xl mb-2"><%= flag %></p>
-        <p class="text-sm font-medium mb-4" style="color: #7a6552;"><%= @moment_country.name %></p>
+        <%# 国旗絵文字 %>
+        <p class="text-5xl mb-3"><%= flag %></p>
+        <%# 英語国名（大文字） %>
+        <p class="text-xs font-bold tracking-widest mb-6" style="color: #7a6552;"><%= english_name %></p>
         <%# 現地時刻（大きく表示） %>
-        <p class="text-6xl font-bold tracking-tight mb-6" style="color: #4B2D1C;">
+        <p class="text-6xl font-bold tracking-tight" style="color: #4B2D1C;">
           <%= @local_time.strftime("%H:%M") %>
         </p>
-        <%# 次へボタン：Step2に切り替える %>
+        <%# 「現地時刻」ラベル %>
+        <p class="text-xs mt-2 mb-8" style="color: #7a6552;">現地時刻</p>
+        <%# 次へボタン：Step2へ進む %>
         <button data-action="bottom-sheet#nextStep"
                 class="w-full py-3 rounded-full text-white font-medium"
                 style="background-color: #b85c38;">
@@ -129,30 +147,42 @@
         </button>
       </div>
 
-      <%# Step2ポップアップ：質問と投稿フォームを表示する。常にhiddenでStep1の「次へ」で表示 %>
+      <%# Step2ポップアップ：定型文を表示する。Step1の「次へ」で表示 %>
       <div data-bottom-sheet-target="step2"
+           class="hidden bg-white rounded-3xl p-8 w-full max-w-sm text-center shadow-xl">
+        <%# 国旗＋英語国名（小さく） %>
+        <p class="text-xs font-bold tracking-widest mb-6" style="color: #7a6552;">
+          <%= flag %> <%= english_name %>
+        </p>
+        <%# 定型文テキスト %>
+        <p class="text-base leading-relaxed mb-8" style="color: #4B2D1C;">
+          <%= @fixed_text %>
+        </p>
+        <%# 次へボタン：Step3へ進む %>
+        <button data-action="bottom-sheet#nextStep"
+                class="w-full py-3 rounded-full text-white font-medium"
+                style="background-color: #b85c38;">
+          次へ →
+        </button>
+      </div>
+
+      <%# Step3ポップアップ：質問と投稿フォームを表示する。Step2の「次へ」で表示 %>
+      <div data-bottom-sheet-target="step3"
            class="hidden bg-white rounded-3xl p-8 w-full max-w-sm shadow-xl">
         <%# 質問文 %>
         <p class="text-base font-medium mb-6 text-center" style="color: #4B2D1C;">
           あなたは今、何をしていますか？
         </p>
-        <%# 投稿フォーム %>
-        <%= form_with model: [@current_moment, Entry.new] do |f| %>
+        <%# Turboを無効化してフォーム送信後のページ全体リロードを防ぐ %>
+        <%= form_with model: [@current_moment, Entry.new], data: { turbo: false } do |f| %>
           <%= f.text_area :body,
                 placeholder: "今を書く。",
                 rows: 4,
                 class: "w-full rounded-xl p-4 text-sm resize-none focus:outline-none border",
                 style: "border-color: #e5d5c5; color: #7a6552;" %>
           <div class="flex gap-3 mt-4">
-            <%# とじるボタン：Step1・Step2両方を閉じる %>
-            <button type="button"
-                    data-action="bottom-sheet#closePopup"
-                    class="flex-1 py-3 rounded-full text-sm font-medium border"
-                    style="color: #7a6552; border-color: #e5d5c5;">
-              とじる
-            </button>
-            <%# 残すボタン：フォームを送信する %>
-            <%= f.submit "残す",
+            <%# のこすボタン：フォームを送信する %>
+            <%= f.submit "のこす",
                   class: "flex-1 py-3 rounded-full text-white font-medium cursor-pointer",
                   style: "background-color: #b85c38;" %>
           </div>
@@ -185,18 +215,21 @@
         <button data-action="bottom-sheet#close"
                 class="text-xl" style="color: #7a6552;">✕</button>
       </div>
-      <%# 投稿フォーム %>
-      <%= form_with model: [@current_moment, Entry.new] do |f| %>
+      <%# 投稿フォーム：Turboを無効化してページ全体リロードで送信する %>
+      <%= form_with model: [@current_moment, Entry.new], data: { turbo: false } do |f| %>
         <%= f.text_area :body,
               placeholder: "今を書く。",
               rows: 4,
               class: "w-full rounded-xl p-4 text-sm resize-none focus:outline-none border",
               style: "border-color: #e5d5c5; color: #7a6552;" %>
-        <%= f.submit "残す",
+        <%# のこすボタン：フォームを送信する %>
+        <%= f.submit "のこす",
               class: "mt-4 w-full py-3 rounded-full text-white font-medium cursor-pointer",
               style: "background-color: #b85c38;" %>
       <% end %>
     </div>
+
+    </div><%# /data-controller="bottom-sheet" %>
 
   <% end %>
 </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,42 +1,111 @@
 <%# ページ全体のラッパー。ボトムシートコントローラーをここにマウントする %>
-<div class="min-h-screen pb-20" style="background-color: #fdf8f3;" data-controller="bottom-sheet">
+<div class="min-h-screen pb-20" style="background-color: #f0ede8;" data-controller="bottom-sheet">
 
   <% if @error_message %>
     <%# 国データがない場合のエラーメッセージ %>
-    <div class="p-6">
+    <div class="p-6" style="background-color: #fdf8f3;">
       <p class="text-sm" style="color: #b85c38;"><%= @error_message %></p>
     </div>
   <% else %>
 
-    <%# ヘッダー：アプリ名と更新ボタン %>
-    <header class="flex items-center justify-between px-6 pt-10 pb-4">
-      <h1 class="text-xl font-bold tracking-wide" style="color: #7a6552;">Meanwhile</h1>
-      <%# 更新ボタン：新しい国をランダムに表示する %>
-      <%= button_to "更新", refresh_path, method: :post,
-            class: "px-4 py-2 rounded-full text-sm font-medium text-white",
-            style: "background-color: #b85c38;" %>
-    </header>
+    <%# 国旗絵文字をcountry_codeから取得する %>
+    <% flag = case @moment_country.country_code
+              when "KR" then "🇰🇷"
+              when "TR" then "🇹🇷"
+              when "BR" then "🇧🇷"
+              when "SE" then "🇸🇪"
+              when "AU" then "🇦🇺"
+              when "KE" then "🇰🇪"
+              end %>
 
-    <%# 国・時刻・定型文のカード %>
-    <section class="mx-6 mt-4 rounded-2xl p-6 shadow-sm bg-white">
-      <%# 国名 %>
-      <p class="text-sm font-medium mb-2" style="color: #7a6552;">
-        <%= @moment_country.name %>
-      </p>
-      <%# 時刻（大きめフォントで表示） %>
-      <p class="text-6xl font-bold tracking-tight mb-4" style="color: #b85c38;">
-        <%= @local_time.strftime("%H:%M") %>
-      </p>
-      <%# 定型文 %>
-      <p class="text-base leading-relaxed" style="color: #7a6552;">
-        <%= @fixed_text %>
-      </p>
-    </section>
+    <%# ヘッダー＋週カレンダー：同じ背景色でシームレスにつなげる %>
+    <div style="background-color: #fdf8f3;">
 
-    <%# 質問文 %>
-    <p class="text-center mt-8 text-sm" style="color: #7a6552;">
-      いま、あなたはどんな時間を過ごしていますか？
-    </p>
+      <%# ヘッダー：左に現地時刻・国情報、右にアプリ名・更新ボタン %>
+      <header class="flex items-center justify-between px-6 pt-8 pb-4">
+
+        <%# 左：現地時刻（大きく）＋国旗＋国名 %>
+        <div>
+          <p class="text-5xl font-bold tracking-tight" style="color: #4B2D1C;">
+            <%= @local_time.strftime("%H:%M") %>
+          </p>
+          <p class="text-sm mt-1" style="color: #7a6552;">
+            <%= flag %> <%= @moment_country.name %>
+          </p>
+        </div>
+
+        <%# 右：アプリ名と更新ボタンを縦並びで配置 %>
+        <div class="flex flex-col items-end gap-2">
+          <%# アプリ名：フォントサイズを大きく %>
+          <p class="text-2xl font-bold" style="color: #4B2D1C;">Meanwhile</p>
+          <%# 更新ボタン：セッションをリセットして新しい国を表示する %>
+          <%= button_to "更新", refresh_path, method: :post,
+                class: "px-4 py-1.5 rounded-full text-sm font-medium text-white",
+                style: "background-color: #b85c38;" %>
+        </div>
+
+      </header>
+
+      <%# 週カレンダー：日〜土の7日分を表示し、今日をハイライトする %>
+      <div class="flex justify-around px-4 pb-5">
+        <% (Date.current.beginning_of_week(:sunday)..Date.current.beginning_of_week(:sunday) + 6).each do |date| %>
+          <div class="flex flex-col items-center gap-1">
+            <%# 曜日ラベル（日本語） %>
+            <span class="text-xs" style="color: #7a6552;">
+              <%= %w[日 月 火 水 木 金 土][date.wday] %>
+            </span>
+            <%# 今日はテラコッタの丸でハイライト、それ以外はそのまま %>
+            <% if date == Date.current %>
+              <span class="w-8 h-8 rounded-full flex items-center justify-center text-sm text-white font-medium"
+                    style="background-color: #b85c38;">
+                <%= date.day %>
+              </span>
+            <% else %>
+              <span class="w-8 h-8 flex items-center justify-center text-sm" style="color: #7a6552;">
+                <%= date.day %>
+              </span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
+    </div><%# /ヘッダー＋カレンダーエリア %>
+
+    <%# チャットエリア：世界の吹き出しとユーザーのentriesを表示する %>
+    <div class="px-4 py-6">
+
+      <%# 世界の吹き出し（左寄せ）：定型文を表示する %>
+      <div class="flex flex-col items-start mb-6">
+        <%# 国旗＋国名ラベル：吹き出しより左にはみ出して配置する %>
+        <p class="text-xs mb-1.5 -ml-2" style="color: #7a6552;">
+          <%= flag %> <%= @moment_country.name %>
+        </p>
+        <%# 吹き出し本体：白背景・角丸・影 %>
+        <div class="bg-white rounded-2xl rounded-tl-sm px-4 py-3 shadow-sm max-w-xs">
+          <p class="text-sm leading-relaxed" style="color: #4B2D1C;"><%= @fixed_text %></p>
+        </div>
+        <%# 現地時刻（吹き出しの下） %>
+        <p class="text-xs mt-1 ml-1" style="color: #7a6552;">
+          <%= @local_time.strftime("%H:%M") %>
+        </p>
+      </div>
+
+      <%# ユーザーのentriesバブル（右寄せ） %>
+      <% @current_moment.entries.each do |entry| %>
+        <div class="flex flex-col items-end mb-4">
+          <%# バブル本体：テラコッタ背景・白テキスト・右下のみ小さい角丸 %>
+          <div class="rounded-2xl rounded-br-sm px-4 py-3 max-w-xs"
+               style="background-color: #b85c38;">
+            <p class="text-sm text-white"><%= entry.body %></p>
+          </div>
+          <%# 投稿時刻（日本時間）をバブルの下に表示する %>
+          <p class="text-xs mt-1 mr-1" style="color: #7a6552;">
+            <%= entry.created_at.in_time_zone("Tokyo").strftime("%H:%M") %>
+          </p>
+        </div>
+      <% end %>
+
+    </div><%# /チャットエリア %>
 
     <%# ＋ボタン：タップするとボトムシートを開く %>
     <button data-action="bottom-sheet#open"

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,16 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
## 実装内容

### TOPページ
* チャット風レイアウト・週カレンダー・吹き出し実装
* ポップアップをStep1（国・時刻）→ Step2（定型文）→ Step3（質問・入力）の3段階構成に変更
* 国名を英語大文字表示（ポップアップのみ）
* 時刻の下に「現地時刻」ラベル追加
* 背景にbackdrop-blur追加
* ボタンテキストを「のこす」に統一（ひらがな）

### 一覧ページ
* カード形式・バブル表示実装

### バグ修正
* 未入力でのこすを押した時のエラーページを修正
* Turboを無効化してフォーム送信後の意図しない国更新を修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Tailwind CSS for modern visual styling
  * Added bottom navigation tabs for page navigation
  * Redesigned moment cards with country flags, dates, and formatted entry bubbles
  * Added multi-step popup interface with bottom sheet input for creating entries

* **Bug Fixes**
  * Improved entry validation to prevent empty submissions

* **Chores**
  * Updated development workflow to run concurrent processes (web server and CSS watcher)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->