### PR TITLE
feat: 本番DBにseedデータを投入するマイグレーションを追加#20

### DIFF
--- a/db/migrate/20260413093005_seed_countries.rb
+++ b/db/migrate/20260413093005_seed_countries.rb
@@ -1,0 +1,21 @@
+class SeedCountries < ActiveRecord::Migration[8.1]
+  def change
+    # 表示対象の国データを定義する
+    countries = [
+      { name: "韓国",           country_code: "KR", timezone: "Asia/Seoul" },
+      { name: "トルコ",         country_code: "TR", timezone: "Europe/Istanbul" },
+      { name: "ブラジル",       country_code: "BR", timezone: "America/Sao_Paulo" },
+      { name: "スウェーデン",   country_code: "SE", timezone: "Europe/Stockholm" },
+      { name: "オーストラリア", country_code: "AU", timezone: "Australia/Sydney" },
+      { name: "ケニア",         country_code: "KE", timezone: "Africa/Nairobi" }
+    ]
+
+    # country_codeで重複チェックしながら登録する（冪等性を保つ）
+    countries.each do |attrs|
+      Country.find_or_create_by!(country_code: attrs[:country_code]) do |country|
+        country.name     = attrs[:name]
+        country.timezone = attrs[:timezone]
+      end
+    end
+  end
+end

--- a/db/migrate/20260413094814_add_unique_index_to_countries_country_code.rb
+++ b/db/migrate/20260413094814_add_unique_index_to_countries_country_code.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToCountriesCountryCode < ActiveRecord::Migration[8.1]
+  def change
+    # country_codeの重複を防ぐユニークインデックスを追加
+    add_index :countries, :country_code, unique: true
+  end
+end

--- a/db/migrate/20260413095729_add_not_null_to_countries_country_code.rb
+++ b/db/migrate/20260413095729_add_not_null_to_countries_country_code.rb
@@ -1,0 +1,6 @@
+class AddNotNullToCountriesCountryCode < ActiveRecord::Migration[8.1]
+  def change
+    # country_codeにNOT NULL制約を追加する
+    change_column_null :countries, :country_code, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_13_094814) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_095729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "countries", force: :cascade do |t|
-    t.string "country_code"
+    t.string "country_code", null: false
     t.datetime "created_at", null: false
     t.string "name"
     t.string "timezone"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_055232) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_094814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_055232) do
     t.string "name"
     t.string "timezone"
     t.datetime "updated_at", null: false
+    t.index ["country_code"], name: "index_countries_on_country_code", unique: true
   end
 
   create_table "entries", force: :cascade do |t|


### PR DESCRIPTION
## 概要
本番環境のDBに国データが入っていないため、マイグレーションファイルでseedデータを投入しました。

## 変更内容
- `db/migrate/`にSeedCountriesマイグレーションを追加
- 6カ国（韓国・トルコ・ブラジル・スウェーデン・オーストラリア・ケニア）を投入
- `find_or_create_by!`で冪等性を確保（重複実行しても安全）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Country records seeded with names, ISO codes, and timezones for use across the app.
* **Bug Fixes**
  * Country codes now enforced as unique and non-null at the database level to prevent duplicates and improve data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->