### PR TITLE
fix: LPスライド2・3のコンテンツを実際の画面に合わせて修正

### DIFF
--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -38,23 +38,30 @@
     </div>
 
     <%# ---------------------------------------- %>
-    <%# スライド2：WHAT IS THIS・アプリの概要説明 %>
+    <%# スライド2：WHAT IS THIS・チャット風レイアウトでアプリの概要説明 %>
     <%# ---------------------------------------- %>
     <div id="slide-2" class="slide absolute inset-0 flex flex-col items-center justify-center px-8 transition-opacity duration-700" style="opacity:0; pointer-events:none;">
 
       <%# セクションタイトル %>
       <p class="text-xs font-bold tracking-widest mb-8" style="color: #b85c38;">WHAT IS THIS</p>
 
-      <%# 世界カード風イメージ %>
-      <div class="bg-white rounded-3xl p-6 w-full max-w-xs shadow-md mb-8">
-        <%# 国旗＋国名（ダミー表示） %>
-        <p class="text-xs font-bold tracking-widest mb-4" style="color: #7a6552;">🇧🇷 BRAZIL</p>
-        <%# 現地時刻（大きく） %>
-        <p class="text-5xl font-bold tracking-tight mb-1" style="color: #4B2D1C;">03:24</p>
-        <%# 定型文サンプル %>
-        <p class="text-xs leading-relaxed mt-3" style="color: #7a6552;">
-          ブラジル では今、深夜の静けさが広がっています。
-        </p>
+      <%# チャット風レイアウト：世界の吹き出し（左）とユーザー投稿（右）のサンプル %>
+      <div class="w-full max-w-xs mb-8">
+        <%# 世界の吹き出し（左寄せ） %>
+        <div class="flex flex-col items-start mb-4">
+          <p class="text-xs mb-1" style="color: #7a6552;">🇸🇪 スウェーデン</p>
+          <div class="bg-white rounded-2xl rounded-tl-sm px-4 py-3 shadow-sm">
+            <p class="text-xs leading-relaxed" style="color: #4B2D1C;">スウェーデン では今、朝の光が静かに広がっています。</p>
+          </div>
+          <p class="text-xs mt-1 ml-1" style="color: #7a6552;">07:12</p>
+        </div>
+        <%# ユーザーの投稿バブル（右寄せ・テラコッタ色） %>
+        <div class="flex flex-col items-end">
+          <div class="rounded-2xl rounded-br-sm px-4 py-3 max-w-xs" style="background-color: #b85c38;">
+            <p class="text-xs text-white">コーヒーを飲みながら仕事中</p>
+          </div>
+          <p class="text-xs mt-1 mr-1" style="color: #7a6552;">16:14</p>
+        </div>
       </div>
 
       <%# 説明文 %>
@@ -66,33 +73,60 @@
     </div>
 
     <%# ---------------------------------------- %>
-    <%# スライド3：一覧画面のイメージ・記録の説明 %>
+    <%# スライド3：RECORD・一覧カード2枚と記録の説明 %>
     <%# ---------------------------------------- %>
-    <div id="slide-3" class="slide absolute inset-0 flex flex-col items-center justify-center px-8 transition-opacity duration-700" style="opacity:0; pointer-events:none;">
+    <div id="slide-3" class="slide absolute inset-0 flex flex-col items-center justify-center px-8 py-12 transition-opacity duration-700" style="opacity:0; pointer-events:none;">
 
-      <%# 一覧画面イメージ（吹き出し風） %>
-      <div class="w-full max-w-xs mb-8">
-        <%# 世界の吹き出し（左） %>
-        <div class="flex flex-col items-start mb-4">
-          <p class="text-xs mb-1" style="color: #7a6552;">🇸🇪 Sweden</p>
-          <div class="bg-white rounded-2xl rounded-tl-sm px-4 py-3 shadow-sm">
-            <p class="text-xs leading-relaxed" style="color: #4B2D1C;">スウェーデン では今、朝の光が静かに広がっています。</p>
+      <%# セクションタイトル %>
+      <p class="text-xs font-bold tracking-widest mb-6" style="color: #b85c38;">RECORD</p>
+
+      <%# 一覧カード2枚：moments/index.html.erbのデザインに合わせる %>
+      <div class="w-full max-w-xs mb-8 space-y-3">
+
+        <%# カード1：トルコ %>
+        <div class="rounded-2xl overflow-hidden shadow-sm">
+          <%# カード上部：国名・日付（左）と現地時刻（右） %>
+          <div class="flex items-center justify-between px-4 py-3" style="background-color: #e8f0f5;">
+            <div>
+              <p class="text-xs font-medium" style="color: #7a6552;">🇹🇷 トルコ</p>
+              <p class="text-xs mt-0.5" style="color: #7a6552;">4月13日 15:03</p>
+            </div>
+            <%# 現地時刻（大きめで右側に表示） %>
+            <p class="text-3xl font-bold tracking-tight" style="color: #4B2D1C;">09:23</p>
           </div>
-          <p class="text-xs mt-1 ml-1" style="color: #7a6552;">07:12</p>
-        </div>
-        <%# ユーザーの投稿（右） %>
-        <div class="flex flex-col items-end">
-          <div class="rounded-2xl rounded-br-sm px-4 py-3 max-w-xs" style="background-color: #b85c38;">
-            <p class="text-xs text-white">コーヒーを飲みながら仕事中</p>
+          <%# カード下部：entryバブル2件（右寄せ） %>
+          <div class="bg-white px-4 py-3">
+            <div class="flex flex-col items-end gap-2">
+              <span class="inline-block px-4 py-2 rounded-full text-xs text-white" style="background-color: #b85c38;">ゲームしています</span>
+              <span class="inline-block px-4 py-2 rounded-full text-xs text-white" style="background-color: #b85c38;">お腹が空いてきた</span>
+            </div>
           </div>
-          <p class="text-xs mt-1 mr-1" style="color: #7a6552;">16:14</p>
         </div>
+
+        <%# カード2：ブラジル %>
+        <div class="rounded-2xl overflow-hidden shadow-sm">
+          <%# カード上部：国名・日付（左）と現地時刻（右） %>
+          <div class="flex items-center justify-between px-4 py-3" style="background-color: #e8f0f5;">
+            <div>
+              <p class="text-xs font-medium" style="color: #7a6552;">🇧🇷 ブラジル</p>
+              <p class="text-xs mt-0.5" style="color: #7a6552;">4月13日 15:22</p>
+            </div>
+            <%# 現地時刻（大きめで右側に表示） %>
+            <p class="text-3xl font-bold tracking-tight" style="color: #4B2D1C;">03:22</p>
+          </div>
+          <%# カード下部：entryバブル1件（右寄せ） %>
+          <div class="bg-white px-4 py-3">
+            <div class="flex flex-col items-end gap-2">
+              <span class="inline-block px-4 py-2 rounded-full text-xs text-white" style="background-color: #b85c38;">ごはん中</span>
+            </div>
+          </div>
+        </div>
+
       </div>
 
-      <%# 説明文 %>
-      <p class="text-sm text-center leading-relaxed" style="color: #4B2D1C;">
-        世界の「今」と自分の投稿がセットで記録されます。<br>
-        あとから振り返ることができます。
+      <%# 説明文：カードとの間にmb-4の余白を追加 %>
+      <p class="text-sm text-center leading-relaxed mb-4" style="color: #4B2D1C;">
+        世界の「今」と自分の投稿がセットで記録され、<br>あとから振り返ることができます。
       </p>
 
     </div>


### PR DESCRIPTION
## 概要
トップページ（LP）のスライド2・3のコンテンツを実際の画面に合わせて修正する。

## 変更内容
- スライド2：世界カード風の表示をホーム画面と同じチャット風レイアウトに変更
- スライド3：セクションラベルを「RECORD」に変更し、一覧カード形式の表示に変更
- 説明文：「世界の「今」と自分の投稿がセットで記録され、あとから振り返ることができます。」に修正

closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned slide layouts for improved presentation
  * Updated Slide 2 with a new chat-style message bubble interface featuring sender and user messages with timestamps
  * Redesigned Slide 3 with a new record-style layout displaying country index cards with enhanced spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->