### PR TITLE
fix: iOSの自動ズームを防ぐためviewportにmaximum-scale=1を追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title><%= content_for(:title) || "Meanwhile" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Meanwhile">
     <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## 概要
iOSのSafari系ブラウザでテキスト入力時に画面が自動ズームする問題を修正する。

## 変更内容
- `application.html.erb`のviewportメタタグにmaximum-scale=1を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mobile viewport configuration to prevent users from zooming beyond the default scale on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->