### PR TITLE
fix: 「1行」を「ひとこと」に修正

### DIFF
--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -161,7 +161,7 @@
           <span class="w-7 h-7 rounded-full flex items-center justify-center text-xs text-white font-bold flex-shrink-0"
                 style="background-color: #b85c38;">2</span>
           <p class="text-sm leading-relaxed" style="color: #4B2D1C;">
-            ＋ボタンで今の自分を1行書き残せます。
+            ＋ボタンで今の自分をひとこと書き残せます。
           </p>
         </div>
         <%# ステップ3 %>
@@ -237,7 +237,7 @@
         <li class="flex items-start gap-3">
           <span class="text-xs px-2 py-0.5 rounded-full text-white flex-shrink-0"
                 style="background-color: #b85c38;">＋</span>
-          <p class="text-sm" style="color: #4B2D1C;">今の自分を1行書き残せます</p>
+          <p class="text-sm" style="color: #4B2D1C;">今の自分をひとこと書き残せます</p>
         </li>
       </ul>
 


### PR DESCRIPTION
## 変更内容
LPとモーダル内の「1行」という表現を「ひとこと」に修正した。

## 変更理由
`entries.body` カラムは `text` 型でバリデーションによる文字数制限がないため、
「1行」という表現は不正確だった。
「ひとこと」は「短く・気軽に」という慣用的なニュアンスでアプリのコンセプトとも合致する。

## 変更箇所
- `app/views/pages/top.html.erb` 164行目・240行目

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated button description text on the landing page for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->